### PR TITLE
Add Dockerfile for containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Python image from the Docker Hub
+FROM python:3.8-slim
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the current directory contents into the container at /usr/src/app
+COPY . .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r dev/requirements.txt
+
+# Make port 8000 available to the world outside this container
+EXPOSE 8000
+
+# Define environment variable
+ENV NAME World
+
+# Run main.py when the container launches
+CMD ["uvicorn", "dev.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION
Created Dockerfile to enable containerization of the FastAPI application. 
- Uses Python 3.8-slim as base image.
- Installs dependencies from `dev/requirements.txt`.
- Exposes FastAPI server on port 8000.
- Runs `main.py` with auto-reload enabled.