### PR TITLE
Update Dockerfile to include watcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ EXPOSE 8000
 # Define environment variable
 ENV NAME World
 
-# Run main.py when the container launches
-CMD ["uvicorn", "dev.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Start both the watcher and the FastAPI app
+CMD ["python", "dev/watcher.py"]


### PR DESCRIPTION
Updated Dockerfile to start both the server and the Git changes watcher script by executing `watcher.py` as the entry point.