### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+.env
+venv/
+ENV/
+env.bak/
+
+# Mac specific
+.DS_Store


### PR DESCRIPTION
This commit introduces a `.gitignore` file that excludes `__pycache__`, Python bytecode, and other unnecessary files/folders to keep the repository clean.